### PR TITLE
Remove references to std::to_string

### DIFF
--- a/src/rcpp_align.cpp
+++ b/src/rcpp_align.cpp
@@ -1,6 +1,10 @@
+#include <sstream>
+
+#define SSTR( x ) dynamic_cast< std::ostringstream & >( ( std::ostringstream() << std::dec << x ) ).str()
 
 #include <Rcpp.h>
 using namespace Rcpp;
+
 
 // [[Rcpp::export]]
 CharacterMatrix rcpp_prepare_alignment_matrix(CharacterMatrix ref){
@@ -21,7 +25,7 @@ CharacterMatrix rcpp_prepare_alignment_matrix(CharacterMatrix ref){
       
       base_counts[b] +=1;
       // printf("bc %i",base_counts[b]);
-      b += std::to_string(base_counts[b]);
+      b += SSTR( base_counts[b] );
       // printf(" %s \n",b.get_cstring());      
       mat2(l,s) = b;
     }


### PR DESCRIPTION
@TS404 can you check that this installs on windows. 
It seems that std::to_string is not yet supported with the R windows build tools
